### PR TITLE
Fix issues with paths, extensions, date, and url_prefix

### DIFF
--- a/hugophotoswipe/album.py
+++ b/hugophotoswipe/album.py
@@ -121,7 +121,7 @@ class Album(object):
         txt = [
                 "+++",
                 "title = \"%s\"" % self.title,
-                "date = \"%s\"" % self.album_date,
+                "date = \"%s\"" % self.album_date if self.album_date != None else "",
                 "%s" % ('\n'.join(proptxt)),
                 "cover = \"%s\"" % coverpath,
                 "+++",

--- a/hugophotoswipe/conf.py
+++ b/hugophotoswipe/conf.py
@@ -26,7 +26,7 @@ SETTINGS_FILENAME = 'hugophotoswipe.yml'
 DEFAULTS = {
         'markdown_dir': None,
         'output_dir': None,
-        'url_prefix': '',
+        'url_prefix': None,
         'output_format': 'jpg',
         'dirname_large': 'large',
         'dirname_small': 'small',

--- a/hugophotoswipe/photo.py
+++ b/hugophotoswipe/photo.py
@@ -254,7 +254,8 @@ class Photo(object):
 
     @property
     def clean_name(self):
-        return self.name.lower().replace(' ', '_')
+        f, ext = os.path.splitext(self.name.lower().replace(' ', '_'))
+        return f
 
 
     @property
@@ -317,12 +318,12 @@ class Photo(object):
 
     @property
     def shortcode(self):
-        large_path = (settings.url_prefix +
-                self.large_path[len(settings.output_dir):])
-        small_path = (settings.url_prefix +
-                self.small_path[len(settings.output_dir):])
-        thumb_path = (settings.url_prefix +
-                self.thumb_path[len(settings.output_dir):])
+        large_path = (('' if settings.url_prefix is None else settings.url_prefix)  +
+                self.large_path[len(settings.output_dir):]).replace('\\','/')
+        small_path = (('' if settings.url_prefix is None else settings.url_prefix) +
+                self.small_path[len(settings.output_dir):]).replace('\\','/')
+        thumb_path = (('' if settings.url_prefix is None else settings.url_prefix) +
+                self.thumb_path[len(settings.output_dir):]).replace('\\','/')
         large_dim = '%ix%i' % self.resize_dims('large')
         small_dim = '%ix%i' % self.resize_dims('small')
         thumb_dim = '%ix%i' % self.resize_dims('thumb')


### PR DESCRIPTION
Paths on Windows use the backslash but the HTML path should use front
slash. When appending dimensions to the resized image filenames the
extension is now correctly placed only at the end. If no date is defined
in the album.yml then no date is emitted in the frontmatter. url_prefix
was meant to be optional but did not have correct defaults, now fixed.