### PR TITLE
Implement minimal EXIF/IPTC tag support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,9 @@ The following options are available in the ``hugophotoswipe.yml`` file:
 | jpeg_progressive | False | Output progressive JPEGs |
 | jpeg_optimize | False | Optimize JPEG output |
 | jpeg_quality | 75 | JPEG quality factor |
+| tag_map | None | Dictionary map of exif/iptc tags to photo properties |
+| exif | None | List of tags to be included or excluded |
+| iptc | None | List of tags to be included or excluded |
 
 Naturally, the jpeg options are only applied when ``output_format`` is 
 ``jpg``.
@@ -41,6 +44,53 @@ dimension will be scaled such that the aspect ratio of the photo remains
 unchanged. When a single number is given, the *maximum* dimension of the photo 
 will be reduced to the given number, and the other dimension is chosen 
 according to the aspect ratio.
+
+EXIF/IPTC Tags
+--------------
+
+You can use the metadata embedded in the photos as a starter to fill out captions
+and copyright information. HugoPhotoSwipe will use this information when you run 
+`hps update` in the following manner:
+1. Prefer the information already specified in the album file
+2. Use the information in the metadata
+
+Using metadata requires a mapping for each field you want to be populated. Currently
+only caption and copyright are supported. In the configuration file, add the `tag_map`
+setting as follows:
+
+```yaml
+tag_map:
+  caption: exif.ImageDescription
+  copyright: exif.Artist
+```
+
+Caption will be saved to the album yaml file with the photo information. You can then
+edit it there if you wish. Because the album file is given priority, your changes will
+not be overridden, even after an update. 
+
+Copyright information is loaded from the photos in the album and populated into the 
+album copyright. All unique photo copyright values are added to the album, comma 
+separated.
+
+The format of the option is: `property: iptc/exif.tag`. Tag may include spaces. A full
+list of tags can be found here:
+* [IPTC tags](https://github.com/jamesacampbell/iptcinfo3/blob/a9cea6cb1981e4ad29cf317d44419e4fd45c2170/iptcinfo3.py#L445)
+* [EXIF tags](https://github.com/python-pillow/Pillow/blob/master/src/PIL/ExifTags.py)
+
+The following two configuration file options allow you more granular control over what
+metadata HugoPhotoSwipe loads from the file. The intended use is to reduce the number of
+tags that are saved. If you want to use a tag in the `tag_map`, it must included or 
+not be excluded. Specifying `include: []` will result in no data being loaded. 
+Not specifying either option will result in all tags being loaded.
+
+```yaml
+iptc:
+  include: ['tag1', 'tag2', ...]
+  exclude: ['tag1', 'tag2', ...]
+exif:
+  include: ['tag1', 'tag2', ...]
+  exclude: ['tag1', 'tag2', ...]
+```
 
 Shortcodes
 ==========

--- a/hugophotoswipe/album.py
+++ b/hugophotoswipe/album.py
@@ -14,7 +14,6 @@ from __future__ import print_function
 
 import logging
 import os
-import pprint
 import shutil
 import yaml
 from PIL import UnidentifiedImageError
@@ -23,7 +22,7 @@ from tqdm import tqdm
 
 from .conf import settings
 from .photo import Photo
-from .utils import yaml_field_to_file, modtime, question_yes_no, mkdirs, cached_property
+from .utils import yaml_field_to_file, modtime, question_yes_no, mkdirs
 
 
 class Album(object):

--- a/hugophotoswipe/conf.py
+++ b/hugophotoswipe/conf.py
@@ -104,6 +104,11 @@ class Settings(object):
 
         self.__dict__.update(entries)
 
+    def __getattr__(self, item):
+        # Fallback for missing settings. Return None instead of raising AttributeError
+        # https://docs.python.org/3/reference/datamodel.html#object.__getattr__
+        return None
+
     def dump(self, dirname=None):
         """ Write settings to yaml file """
         dirname = "" if dirname is None else dirname

--- a/hugophotoswipe/hugophotoswipe.py
+++ b/hugophotoswipe/hugophotoswipe.py
@@ -53,6 +53,7 @@ class HugoPhotoSwipe(object):
 
     def update(self, name=None):
         """ Update all markdown and resizes for each album """
+        logging.getLogger().setLevel(logging.INFO)
         if name is None:
             for album in self._albums:
                 print("Updating album: %s" % album.name)

--- a/hugophotoswipe/hugophotoswipe.py
+++ b/hugophotoswipe/hugophotoswipe.py
@@ -53,7 +53,6 @@ class HugoPhotoSwipe(object):
 
     def update(self, name=None):
         """ Update all markdown and resizes for each album """
-        logging.getLogger().setLevel(logging.INFO)
         if name is None:
             for album in self._albums:
                 print("Updating album: %s" % album.name)

--- a/hugophotoswipe/photo.py
+++ b/hugophotoswipe/photo.py
@@ -16,10 +16,14 @@ from __future__ import print_function, division
 import hashlib
 import logging
 import os
+import pprint
+
 import smartcrop
 import tempfile
 
-from PIL import Image, ExifTags
+from PIL.TiffImagePlugin import IFDRational
+from PIL import Image
+from PIL.ExifTags import TAGS, GPSTAGS
 from functools import total_ordering
 from textwrap import wrap
 from subprocess import check_output
@@ -70,11 +74,16 @@ class Photo(object):
         # names
         self.name = name
         self.alt = alt
-        self.caption = caption
+        self._caption = caption
 
         # other
-        self.copyright = copyright
+        self._copyright = copyright
         self.cover_path = None
+        self._exif = None
+        self._iptc = None
+
+        # process load image to ensure it's a valid image.
+        self.original_image
 
     ################
     #              #
@@ -85,16 +94,14 @@ class Photo(object):
     @cached_property
     def original_image(self):
         """ Open original image and if needed rotate it according to EXIF """
-        img = Image.open(self.original_path)
         # if there is no exif data, simply return the image
-        exif = img._getexif()
+        img = Image.open(self.original_path)
+        exif = self.exif
         if exif is None:
             return img
 
         # get the orientation tag code from the ExifTags dict
-        orientation = next(
-            (k for k, v in ExifTags.TAGS.items() if v == "Orientation"), None
-        )
+        orientation = exif.get('Orientation')
         if orientation is None:
             print("Couldn't find orientation tag in ExifTags.TAGS")
             return img
@@ -113,6 +120,99 @@ class Photo(object):
 
         # fallback for unhandled rotation tags
         return img
+
+    @property
+    def iptc(self):
+        from iptcinfo3 import IPTCInfo, c_datasets_r
+
+        if self._iptc is None:
+            if settings.iptc:
+                tags = _filter_tags(c_datasets_r.keys(),
+                                    settings.iptc.get('include'),
+                                    settings.iptc.get('exclude'))
+            else:
+                tags = c_datasets_r.keys()
+
+            info = IPTCInfo(self.original_path)
+            iptc = {}
+            for k in tags:
+                if type(info[k]) is bytes:
+                    iptc[k] = info[k].decode('utf-8')
+                elif type(info[k]) is list:
+                    l = []
+                    for v in info[k]:
+                        l.append(v.decode('utf-8'))
+                    iptc[k] = l
+                else:
+                    iptc[k] = info[k]
+            self._iptc = iptc
+
+        return self._iptc
+
+    @property
+    def exif(self):
+        if self._exif is None:
+            if settings.exif:
+                tags = set(_filter_tags(TAGS.values(),
+                                    settings.exif.get('include'),
+                                    settings.exif.get('exclude')))
+                tags.add('Orientation')  # always need this for resize
+            else:
+                tags = TAGS.values()
+
+            exif_data = {}
+            exif = Image.open(self.original_path).getexif()
+            for k, v in exif.items():
+                decoded = TAGS.get(k)
+                if decoded in tags and not isinstance(v, IFDRational):  # Filter complex data values
+                    exif_data[decoded] = v
+            for k, v in exif_data.pop('GPSInfo', {}).items():
+                decoded = GPSTAGS.get(k, k)
+                exif_data[decoded] = v
+            self._exif = exif_data
+            del exif
+
+        return self._exif
+
+    def _get_tag_value(self, tag):
+        assert tag is not None
+        try:
+            obj, t = tag.split('.')
+        except Exception as e:
+            logging.warning(e)
+            raise ValueError(f"Tag improperly formatted. Should be of format (exif/iptc).tag Provided: ({tag})")
+        if obj.lower() not in ['exif', 'iptc']:
+            raise ValueError(f"Tags can only reference iptc or exif data. ({tag})")
+        o = getattr(self, obj.lower(), {})
+        if o is None:
+            logging.warning(f'Tag "{tag}" specified but {obj} not loaded. Returning "".')
+            o = {}
+        return o.get(t, "")
+
+    @property
+    def caption(self):
+        if self._caption:
+            return self._caption
+        elif settings.tag_map and settings.tag_map.get('caption'):
+            return str(self._get_tag_value(settings.tag_map.get('caption')))
+        return ""
+
+    @property
+    def copyright(self):
+        if self._copyright:
+            return self._copyright
+        elif settings.tag_map and settings.tag_map.get('copyright'):
+            return str(self._get_tag_value(settings.tag_map.get('copyright')))
+        return ""
+
+    def __getattribute__(self, attr):
+        """ Allow property style access to all tags defined in settings.tag_map """
+        try:
+            return super().__getattribute__(attr)
+        except AttributeError as e:
+            if settings.tag_map and settings.tag_map.get(attr):
+                return self._get_tag_value(settings.tag_map.get(attr))
+            raise e
 
     def has_sizes(self):
         """ Check if all necessary sizes exist on disk """
@@ -458,3 +558,10 @@ class Photo(object):
 
     def __eq__(self, other):
         return self.__key() == other.__key()
+
+
+def _filter_tags(tags, include=None, exclude=None):
+    exc = lambda k: True if not exclude else k not in exclude
+    inc = lambda k: True if not include else k in include
+    return filter(exc, filter(inc, tags))
+

--- a/hugophotoswipe/photo.py
+++ b/hugophotoswipe/photo.py
@@ -82,7 +82,7 @@ class Photo(object):
         self._exif = None
         self._iptc = None
 
-        # process load image to ensure it's a valid image.
+        # process image to ensure it's a valid image.
         self.original_image
 
     ################

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ REQUIRED = [
     "pyyaml",
     "tqdm",
     "smartcrop",
+    "iptcinfo3",
 ]
 
 docs_require = []


### PR DESCRIPTION
Use PIL's TAGS to deal with EXIF. Use iptcinfo3 to deal with IPTC tags. Allows to use these as fallback options for copyright
and caption of photos. As a sample use-case reads captions from the photos and the album copyright can be determined from the copyright of the photos in it.  Will not change the default behaviour without adding the setting tag_map, exif or iptc to the configuration file. If the copyright use-case is not desired, drop the changes to the album.py file in their entirety.

To make it work more easily, without constant try except clauses for every setting possible, the Settings object now returns None when accessing a property that is not set instead of throwing an AttributeError. I left this fundamental change to the codebase as a separate commit but not changing this behaviour will require a re-write of some code in this pull request.

This feature is the baseline for integrating with #31 to output EXIF/IPTC tags into the front matter of every photo.