### PR TITLE
Implement minimal EXIF and IPTC tag support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -69,8 +69,8 @@ edit it there if you wish. Because the album file is given priority, your change
 not be overridden, even after an update. Copyright is not yet used as this is currently 
 an album-level property.
 
-The format of the option is: `property: iptc/exif.tag`. Tag may include spaces. A full
-list of tags can be found here:
+The format of the option is: `<property_name>: iptc.<tag_name>` or `<property_name>:exif.<tag_name>` 
+(for example: `copyright: exif.Artist`). Tag may include spaces. A full list of tags can be found here:
 * [IPTC tags](https://github.com/jamesacampbell/iptcinfo3/blob/a9cea6cb1981e4ad29cf317d44419e4fd45c2170/iptcinfo3.py#L445)
 * [EXIF tags](https://github.com/python-pillow/Pillow/blob/master/src/PIL/ExifTags.py)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,9 @@ The following options are available in the ``hugophotoswipe.yml`` file:
 | jpeg_progressive | False | Output progressive JPEGs |
 | jpeg_optimize | False | Optimize JPEG output |
 | jpeg_quality | 75 | JPEG quality factor |
+| tag_map | None | Dictionary map of exif/iptc tags to photo properties |
+| exif | None | List of tags to be included or excluded |
+| iptc | None | List of tags to be included or excluded |
 
 Naturally, the jpeg options are only applied when ``output_format`` is 
 ``jpg``.
@@ -41,6 +44,50 @@ dimension will be scaled such that the aspect ratio of the photo remains
 unchanged. When a single number is given, the *maximum* dimension of the photo 
 will be reduced to the given number, and the other dimension is chosen 
 according to the aspect ratio.
+
+EXIF/IPTC Tags
+--------------
+
+You can use the metadata embedded in the photos as a starter to fill out captions
+and copyright information. HugoPhotoSwipe will use this information when you run 
+`hps update` in the following manner:
+1. Prefer the information already specified in the album file
+2. Use the information in the metadata
+
+Using metadata requires a mapping for each field you want to be populated. Currently
+only caption and copyright are supported. In the configuration file, add the `tag_map`
+setting as follows:
+
+```yaml
+tag_map:
+  caption: exif.ImageDescription
+  copyright: exif.Artist
+```
+
+Caption will be saved to the album yaml file with the photo information. You can then
+edit it there if you wish. Because the album file is given priority, your changes will
+not be overridden, even after an update. Copyright is not yet used as this is currently 
+an album-level property.
+
+The format of the option is: `property: iptc/exif.tag`. Tag may include spaces. A full
+list of tags can be found here:
+* [IPTC tags](https://github.com/jamesacampbell/iptcinfo3/blob/a9cea6cb1981e4ad29cf317d44419e4fd45c2170/iptcinfo3.py#L445)
+* [EXIF tags](https://github.com/python-pillow/Pillow/blob/master/src/PIL/ExifTags.py)
+
+The following two configuration file options allow you more granular control over what
+metadata HugoPhotoSwipe loads from the file. The intended use is to reduce the number of
+tags that are saved. If you want to use a tag in the `tag_map`, it must included or 
+not be excluded. Specifying `include: []` will result in no data being loaded. 
+Not specifying either option will result in all tags being loaded.
+
+```yaml
+iptc:
+  include: ['tag1', 'tag2', ...]
+  exclude: ['tag1', 'tag2', ...]
+exif:
+  include: ['tag1', 'tag2', ...]
+  exclude: ['tag1', 'tag2', ...]
+```
 
 Shortcodes
 ==========

--- a/hugophotoswipe/config.py
+++ b/hugophotoswipe/config.py
@@ -53,6 +53,9 @@ DEFAULTS = {
     "jpeg_quality": 75,
     "fast": False,
     "verbose": False,
+    "exif": None,
+    "iptc": None,
+    "tag_map": None,
 }
 
 DONT_DUMP = ["verbose", "fast"]

--- a/hugophotoswipe/photo.py
+++ b/hugophotoswipe/photo.py
@@ -29,7 +29,7 @@ from subprocess import check_output
 from .config import settings
 from .utils import cached_property
 
-logging.getLogger('iptcinfo').setLevel('ERROR')  # Avoid warnings about missing / undecoded IPTC tags.
+# logging.getLogger('iptcinfo').setLevel('ERROR')  # Avoid warnings about missing / undecoded IPTC tags.
 
 
 @total_ordering
@@ -97,12 +97,13 @@ class Photo(object):
             # if no orientation is defined in the exif, return the image
             return img
 
+        logging.warning(f"Issue with orientation: ({orientation}).")
         # rotate the image according to the exif
-        if exif[orientation] == 3:
+        if orientation == 3:
             return img.rotate(180, expand=True)
-        elif exif[orientation] == 6:
+        elif orientation == 6:
             return img.rotate(270, expand=True)
-        elif exif[orientation] == 8:
+        elif orientation == 8:
             return img.rotate(90, expand=True)
 
         # fallback for unhandled rotation tags

--- a/hugophotoswipe/photo.py
+++ b/hugophotoswipe/photo.py
@@ -147,10 +147,7 @@ class Photo(object):
             if type(info[k]) is bytes:
                 iptc[k] = info[k].decode('utf-8')
             elif type(info[k]) is list:
-                l = []
-                for v in info[k]:
-                    l.append(v.decode('utf-8'))
-                iptc[k] = l
+                iptc[k] = [v.decode('utf-8') for v in info[k]]
             else:
                 iptc[k] = info[k]
         self._iptc = iptc

--- a/hugophotoswipe/photo.py
+++ b/hugophotoswipe/photo.py
@@ -198,15 +198,6 @@ class Photo(object):
             return str(self._get_tag_value(settings.tag_map.get('copyright')))
         return ""
 
-    def __getattribute__(self, attr):
-        """ Allow property style access to all tags defined in settings.tag_map """
-        try:
-            return super().__getattribute__(attr)
-        except AttributeError as e:
-            if settings.tag_map and settings.tag_map.get(attr):
-                return self._get_tag_value(settings.tag_map.get(attr))
-            raise e
-
     def has_sizes(self):
         """ Check if all necessary sizes exist on disk """
         if self.name is None:

--- a/hugophotoswipe/photo.py
+++ b/hugophotoswipe/photo.py
@@ -98,11 +98,11 @@ class Photo(object):
             return img
 
         # rotate the image according to the exif
-        if exif[orientation] == 3:
+        if orientation == 3:
             return img.rotate(180, expand=True)
-        elif exif[orientation] == 6:
+        elif orientation == 6:
             return img.rotate(270, expand=True)
-        elif exif[orientation] == 8:
+        elif orientation == 8:
             return img.rotate(90, expand=True)
 
         # fallback for unhandled rotation tags

--- a/hugophotoswipe/photo.py
+++ b/hugophotoswipe/photo.py
@@ -168,15 +168,14 @@ class Photo(object):
         assert tag is not None
         try:
             obj, t = tag.split('.')
-        except Exception as e:
-            logging.warning(e)
+        except ValueError as e:
             raise ValueError(
-                f"Tag improperly formatted. "
-                f"Tag should be of format iptc.<tag_name> or exif.<tag_name>. Provided: ({tag})")
+                f"Tag(s) improperly formatted. "
+                f"Tags should be of format iptc.<tag_name> or exif.<tag_name>. Provided: ({tag})")
         if obj.lower() not in ['exif', 'iptc']:
             raise ValueError(
                 f"Tags can only reference iptc or exif data. "
-                f"Tag should be of format: iptc.<tag_name> or exif.<tag_name>. Provided: ({tag})")
+                f"Tags should be of format: iptc.<tag_name> or exif.<tag_name>. Provided: ({tag})")
         o = getattr(self, obj.lower(), {})
         if o is None:
             logging.warning(f'Tag "{tag}" specified but {obj} not loaded. Returning "".')

--- a/hugophotoswipe/photo.py
+++ b/hugophotoswipe/photo.py
@@ -29,6 +29,8 @@ from subprocess import check_output
 from .config import settings
 from .utils import cached_property
 
+logging.getLogger('iptcinfo').setLevel('ERROR')  # Avoid warnings about missing / undecoded IPTC tags.
+
 
 @total_ordering
 class Photo(object):

--- a/hugophotoswipe/photo.py
+++ b/hugophotoswipe/photo.py
@@ -90,11 +90,7 @@ class Photo(object):
         # get the orientation tag code from the ExifTags dict
         orientation = exif.get('Orientation')
         if orientation is None:
-            print("Couldn't find orientation tag in ExifTags.TAGS")
-            return img
-
-        # if no orientation is defined in the exif, return the image
-        if not orientation in exif:
+            # if no orientation is defined in the exif, return the image
             return img
 
         # rotate the image according to the exif

--- a/hugophotoswipe/photo.py
+++ b/hugophotoswipe/photo.py
@@ -33,13 +33,13 @@ from .utils import cached_property
 @total_ordering
 class Photo(object):
     def __init__(
-        self,
-        album_name=None,
-        original_path=None,
-        name=None,
-        alt=None,
-        caption=None,
-        copyright=None,
+            self,
+            album_name=None,
+            original_path=None,
+            name=None,
+            alt=None,
+            caption=None,
+            copyright=None,
     ):
         # album
         self.album_name = album_name
@@ -173,9 +173,13 @@ class Photo(object):
             obj, t = tag.split('.')
         except Exception as e:
             logging.warning(e)
-            raise ValueError(f"Tag improperly formatted. Should be of format (exif/iptc).tag Provided: ({tag})")
+            raise ValueError(
+                f"Tag improperly formatted. "
+                f"Tag should be of format iptc.<tag_name> or exif.<tag_name>. Provided: ({tag})")
         if obj.lower() not in ['exif', 'iptc']:
-            raise ValueError(f"Tags can only reference iptc or exif data. ({tag})")
+            raise ValueError(
+                f"Tags can only reference iptc or exif data. "
+                f"Tag should be of format: iptc.<tag_name> or exif.<tag_name>. Provided: ({tag})")
         o = getattr(self, obj.lower(), {})
         if o is None:
             logging.warning(f'Tag "{tag}" specified but {obj} not loaded. Returning "".')
@@ -218,7 +222,7 @@ class Photo(object):
         if not os.path.exists(self.thumb_path):
             return False
         if (not self.cover_path is None) and (
-            not os.path.exists(self.cover_path)
+                not os.path.exists(self.cover_path)
         ):
             return False
         return True
@@ -536,4 +540,3 @@ def _filter_tags(tags, include=None, exclude=None):
     exc = lambda k: True if not exclude else k not in exclude
     inc = lambda k: True if not include else k in include
     return filter(exc, filter(inc, tags))
-

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ REQUIRED = [
     "pyyaml",
     "tqdm",
     "smartcrop",
+    "iptcinfo3",
 ]
 
 docs_require = []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,6 +32,8 @@ class ConfigTestCase(unittest.TestCase):
             self.assertEqual(line(fp), "dirname_large: large")
             self.assertEqual(line(fp), "dirname_small: small")
             self.assertEqual(line(fp), "dirname_thumb: thumb")
+            self.assertEqual(line(fp), "exif:")
+            self.assertEqual(line(fp), "iptc:")
             self.assertEqual(line(fp), "jpeg_optimize: False")
             self.assertEqual(line(fp), "jpeg_progressive: False")
             self.assertEqual(line(fp), "jpeg_quality: 75")
@@ -40,6 +42,7 @@ class ConfigTestCase(unittest.TestCase):
             self.assertEqual(line(fp), "output_format: jpg")
             self.assertEqual(line(fp), "photo_dir: photos")
             self.assertEqual(line(fp), "smartcrop_js_path:")
+            self.assertEqual(line(fp), "tag_map:")
             self.assertEqual(line(fp), "url_prefix:")
             self.assertEqual(line(fp), "use_smartcrop_js: False")
 
@@ -65,6 +68,8 @@ class ConfigTestCase(unittest.TestCase):
             self.assertEqual(line(fp), "dirname_large: large")
             self.assertEqual(line(fp), "dirname_small: small")
             self.assertEqual(line(fp), "dirname_thumb: thumb")
+            self.assertEqual(line(fp), "exif:")
+            self.assertEqual(line(fp), "iptc:")
             self.assertEqual(line(fp), "jpeg_optimize: False")
             self.assertEqual(line(fp), "jpeg_progressive: True")
             self.assertEqual(line(fp), "jpeg_quality: 75")
@@ -73,6 +78,7 @@ class ConfigTestCase(unittest.TestCase):
             self.assertEqual(line(fp), "output_format: jpg")
             self.assertEqual(line(fp), "photo_dir: photo_files")
             self.assertEqual(line(fp), "smartcrop_js_path:")
+            self.assertEqual(line(fp), "tag_map:")
             self.assertEqual(line(fp), "url_prefix:")
             self.assertEqual(line(fp), "use_smartcrop_js: False")
 

--- a/tests/test_photo.py
+++ b/tests/test_photo.py
@@ -238,6 +238,25 @@ class PhotoTagsTestCase(unittest.TestCase):
         self.assertEqual("Free (do whatever you want) high-resolution photos. unsplash.com/license",
                          self.photo.copyright)
 
+    def test_incorrect_tags_namespace_value_error(self):
+        # Configure Tag Map to point copyright to a filled-out EXIF tag.
+        setattr(settings, "tag_map", {"copyright": "bad.Copyright"})
+        with self.assertRaises(ValueError) as cm:
+            _ = self.photo.copyright
+        self.assertEqual(cm.exception.args[0],
+                         "Tags can only reference iptc or exif data. "
+                         "Tags should be of format: iptc.<tag_name> or exif.<tag_name>. Provided: (bad.Copyright)")
+
+    def test_incorrect_tags_format_value_error(self):
+        # Configure Tag Map to point copyright to a filled-out EXIF tag.
+        setattr(settings, "tag_map", {"copyright": "exif_Copyright"})
+        with self.assertRaises(ValueError) as cm:
+            _ = self.photo.copyright
+        # print(cm.exception)
+        self.assertEqual(cm.exception.args[0],
+                         f"Tag(s) improperly formatted. "
+                         f"Tags should be of format iptc.<tag_name> or exif.<tag_name>. Provided: (exif_Copyright)")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_photo.py
+++ b/tests/test_photo.py
@@ -196,7 +196,47 @@ class PhotoTestCase(unittest.TestCase):
 
     def test_sha256sum(self):
         self.assertEqual(self.photo.sha256sum(),
-"c2fdf14c548a08032fd06e6036197fc7e9c262e6d06fac40e54ec5dd2ce6912f")
+                         "c2fdf14c548a08032fd06e6036197fc7e9c262e6d06fac40e54ec5dd2ce6912f")
+
+
+class PhotoTagsTestCase(unittest.TestCase):
+    def setUp(self):
+        here = os.path.dirname(os.path.realpath(__file__))
+        test_file = os.path.join(here, "data", "dogs", "dog-2.jpg")
+        self.photo = Photo(
+            album_name="test_album",
+            original_path=test_file,
+            name="dog_2",
+            alt="Alt text",
+            caption="caption text",
+            copyright=None,
+        )
+        self._tmpdir = tempfile.mkdtemp(prefix="hps_photo_")
+        # Reset settings after each test
+        settings.__init__(**dict())
+
+    def tearDown(self):
+        shutil.rmtree(self._tmpdir)
+
+    def test_iptc_tags_retain_default_behaviour(self):
+        setattr(settings, "tag_map", {"caption": "iptc.headline"})
+        self.assertEqual("caption text", self.photo.caption)
+
+    def test_iptc_tags_backfill(self):
+        setattr(self.photo, "_caption", None)
+        setattr(settings, "tag_map", {"caption": "iptc.headline"})
+        self.assertEqual("A photo by Andrew Branch. unsplash.com/photos/owWHkSUmCCQ", self.photo.caption)
+
+    def test_exif_tags_retain_default_behaviour(self):
+        setattr(settings, "tag_map", {"copyright": "exif.Copyright"})
+        setattr(self.photo, "_copyright", "The other dog")
+        self.assertEqual("The other dog", self.photo.copyright)
+
+    def test_exif_tags_backfill(self):
+        # Configure Tag Map to point copyright to a filled-out EXIF tag.
+        setattr(settings, "tag_map", {"copyright": "exif.Copyright"})
+        self.assertEqual("Free (do whatever you want) high-resolution photos. unsplash.com/license",
+                         self.photo.copyright)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Updated version of PR #32.

Rebased on the updated version of HPS. I've added tests to cover the EXIF and IPTC additions.
Minor changes to the configuration tests are required as this PR introduces 3 potential new config file entries. These have been added to the config tests.

This feature allows:
- Back filling the copyright or caption data from an EXIF or IPTC metadata field if not defined in the album.yml
- Prepare for allowing access to all tags in the shortcode by making (a subset of) tags available as a property of the Photo object